### PR TITLE
テストデプロイ時の不具合修正（3回目）

### DIFF
--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -16,7 +16,7 @@ class Gadget < ApplicationRecord
   # メソッド
   # ファイルが添付されているかを確認し、添付されていない場合には指定のファイルを添付するメソッド
   def get_gadget_image
-    (gadget_image.attached?) ? gadget_image : 'no_gadget_image'
+    (gadget_image.attached?) ? gadget_image : 'no_gadget_image.png'
   end
 
   # DBから取得した投稿日を整形するためのメソッド

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   # メソッド
   # ファイルが添付されているかを確認し、添付されていない場合には指定のファイルを添付するメソッド
   def get_profile_image
-    (profile_image.attached?) ? profile_image : 'no_profile_image'
+    (profile_image.attached?) ? profile_image : 'no_profile_image.png'
   end
 
   # reverse_of_relationshipsテーブルのカラムfollower_idにuser.idが存在するかを確認するメソッド


### PR DESCRIPTION
プロフィール画像、ガジェット画像が投稿されない場合に表示する画像のファイル名に、拡張子の記載が不足していたため修正